### PR TITLE
fix is-xml-string? need to realize xml data completely and recursively

### DIFF
--- a/src/uruk/core.clj
+++ b/src/uruk/core.clj
@@ -5,6 +5,7 @@
             clojure.edn
             [clojure.data.json :as json]
             [clojure.data.xml :as xml]
+            [clojure.data.xml.tree :as tree]
             [slingshot.slingshot :as sling])
   (:import [java.util.logging Logger]
            java.net.URI
@@ -1054,7 +1055,7 @@
   [s]
   (if-not (string? s)
     false
-    (try (if (xml/parse-str s) true false)
+    (try (if (doall (tree/flatten-elements [(xml/parse-str s)])) true false)
          (catch javax.xml.stream.XMLStreamException xmlse
            false)
          (catch Exception e


### PR DESCRIPTION
Fix `is-xml-string?`: we need to realize xml data completely and recursively, otherwise we're bitten by the lazyness of `clojure.data.xml/parse-str`

(It would work to use `clojure.data.xml/emit-str` but actually `emit-str`
just does a flatten-elements on the sequence of the element and then
writes that; let's save us that writing.)

Example repl session without this fix to demonstrate the problem:
```
(require 'clojure.data.xml)
(clojure.data.xml/emit-str (clojure.data.xml/parse-str "<xml><foo</xml>"))
=> XMLStreamException ParseError at [row,col]:[1,10]
     Message: Element type "foo" must be followed by either attribute specifications, ">" or "/>".  com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.next (XMLStreamReaderImpl.java:596)
;; but:
(#'uruk.core/is-xml-string? "<xml><foo</xml>")
=> true
```

with this fix, you get the correct:
```
(#'uruk.core/is-xml-string? "<xml><foo</xml>")
=> false
```