### PR TITLE
Update dependencies (including MarkLogic 9.0-3 and Clojure 1.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Multiple database updates that must occur together can take advantage of transac
 We translate the original Java to Clojure, taking advantage of Clojure’s `with-open` idiom:
 
 ``` clojure
-(with-open [session (uruk/create-session db {:transaction-mode :update})]
+;; Open a session and configure it to trigger multi-statement transaction use:
+(with-open [session (uruk/create-session db {:auto-commit? false :update-mode true})]
   ;; The first request (query) starts a new, multi-statement transaction:
   (uruk/execute-xquery session "xdmp:document-insert('/docs/mst1.xml', <data><stuff/></data>)")
 
@@ -291,6 +292,7 @@ Uruk is sturdy and ready for production. However, some aspects of the XCC/J API 
 
 ## TODO
   - look into possibly using clojure.spec (once Clojure 1.9 is stable)
+  - generative testing (for instance, in `as-expected-session-config?`)
   - ensure `insert-element` robustly covers needed use cases
   - possibly implement REx to automatically parse XQuery for XDM variable types
   - possibly implement `use-fixtures` within tests to create user with appropriate permissions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [<img align="right" src="resources/gilgamesh-tablet.jpg"/>](https://en.wikipedia.org/wiki/File:Tablet_V_of_the_Epic_of_Gligamesh.JPG)
 Uruk is a Clojure library wrapping [MarkLogic](http://www.marklogic.com/what-is-marklogic/)'s [XML Content Connector for Java (XCC/J)](https://developer.marklogic.com/products/xcc). Uruk empowers you to access your Enterprise NoSQL database from Clojure.
 
-By leveraging MarkLogic's XCC API, you can use Uruk to:
+By using Uruk, you can leverage MarkLogic's XCC API to:
 
  - evaluate stored XQuery programs
  - dynamically construct and evaluate XQuery programs
@@ -10,18 +10,17 @@ By leveraging MarkLogic's XCC API, you can use Uruk to:
 
 The name Uruk comes from the [ancient Mesopotamian city-state](http://www.metmuseum.org/toah/hd/uruk/hd_uruk.htm) and [period](http://www.metmuseum.org/toah/hd/wrtg/hd_wrtg.htm) in which some of the oldest known writing has been found. One can see Uruk as perhaps the first document database—and it certainly wasn’t organized relationally.
 
-This project is sponsored by [LambdaWerk](https://lambdawerk.com/home). It is part of the emacs [XQuery-mode](https://github.com/xquery-mode/) stack.
+This project is sponsored by [LambdaWerk](https://lambdawerk.com/home). It is part of the [XQuery-mode](https://github.com/xquery-mode/) stack for working with XQuery in emacs.
 
 
 ## Installation
-
-(To use Uruk, you need MarkLogic on your system. [Instructions for that](#marklogic-installation) are below.)
-
 [![Clojars Project](https://img.shields.io/clojars/v/uruk.svg)](https://clojars.org/uruk)
 
 In your *project.clj* dependencies: `[uruk "0.3.9"]`
 
 In your namespace: `(:require [uruk.core :as uruk])`. (I also like `ur` as an alias, for brevity. Delightfully, Ur is another [ancient city-state with ties to the origins of written documents](https://en.wikipedia.org/wiki/Ur).)
+
+To run Uruk locally, you need MarkLogic [installed on your machine](https://docs.marklogic.com/guide/installation/procedures#id_28962). To run Uruk's tests or examples, see [configuring MarkLogic for Uruk](#marklogic-configuration) below.)
 
 
 ## Usage
@@ -32,21 +31,25 @@ For some background, see the [XCC Developer's Guide](https://docs.marklogic.com/
 
 For examples of how to use specific types and functions, see `test/uruk/core_test.clj`. Examples in this README are included for reference in `src/uruk/examples/readme.clj`.
 
-### MarkLogic installation
+### MarkLogic configuration
 
-To play around with Uruk locally and to run the tests, you'll need to install and configure MarkLogic on your machine.
+To run Uruk's tests or evaluate its examples directly in a REPL, you'll need to configure MarkLogic on your machine to match the settings Uruk expects. If you have an existing MarkLogic install, feel free to skip these steps and instead point your REPL at your own database.
 
 1. Install and start a local MarkLogic server via the [Install Instructions](https://docs.marklogic.com/guide/installation/procedures#id_28962).
 
-2. Navigate to http://localhost:8000/appservices/ and follow instructions for [Creating a New XDBC Server](https://docs.marklogic.com/guide/admin/xdbc#id_21458) in the [Administrator's Guide](https://docs.marklogic.com/guide/admin/xdbc) to create an XDBC server and an UrukDB database.
+1. [Open the Admin Interface](https://docs.marklogic.com/guide/admin/admin_inter#id_69619) at http://localhost:8001/ 
 
-3. Create a forest (e.g. "UrukForest") and attach it to the UrukDB database you just created.
+1. [Create a forest](https://docs.marklogic.com/guide/admin/getting_started#id_13483) named "UrukForest"
+ 
+1. [Create a database](https://docs.marklogic.com/guide/admin/databases#id_60599) named "UrukDB". Attach it to UrukForest but otherwise leave use the default settings.
+  
+1. [Create an XDBC Server](https://docs.marklogic.com/guide/admin/xdbc#id_21458) named "UrukServer" on port 8383.
 
-4. Create a `uruk-tester-role` with every default permission for `xa`, URI privilege `view-uri`, and execute-privileges `any-uri`, `xdmp:external-binary`, and `xdmp:timestamp` (needed for specific tests)
+4. Create role `uruk-tester-role` with URI privilege `view-uri`, execute-privileges `any-uri`, `xdmp:external-binary`, and `xdmp:timestamp`, and all the default document permissions (`node-update`, `execute`, `update`, `insert`, and `read`) for `xa` (these are all needed for specific tests).
 
-5. Create `uruk-tester` user with password "password" and roles of `xa` and `uruk-tester-role`. This will be necessary to run tests and README examples.
+5. Create user `uruk-tester` with password "password" and roles of `xa` and `uruk-tester-role`. This will be used to run tests and README examples.
 
-6. Finally, add environment variable `URUK_TEST_IMG_PATH` (e.g. `export URUK_TEST_IMG_PATH=/path/to/uruk/resources/ml-favicon.ico`) to your Bash profile (*.bashrc*).
+6. Finally, add environment variable `URUK_TEST_IMG_PATH` (e.g. `export URUK_TEST_IMG_PATH=/path/to/uruk/resources/ml-favicon.ico`) to your Bash profile (*.bashrc*) and make sure it's available to your environment.
 
 You should now be able to run `lein test` and, if you start up a REPL, the examples in *test/uruk/core_test.clj*.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This project is sponsored by [LambdaWerk](https://lambdawerk.com/home). It is pa
 
 
 ## Installation
+
+(To use Uruk, you need MarkLogic on your system. [Instructions for that](#marklogic-installation) are below.)
+
 [![Clojars Project](https://img.shields.io/clojars/v/uruk.svg)](https://clojars.org/uruk)
 
 In your *project.clj* dependencies: `[uruk "0.3.9"]`
@@ -43,7 +46,7 @@ To play around with Uruk locally and to run the tests, you'll need to install an
 
 5. Create `uruk-tester` user with password "password" and roles of `xa` and `uruk-tester-role`. This will be necessary to run tests and README examples.
 
-6. Finally, add environment variable `URUK_TEST_IMG_PATH` (e.g. `export URUK_TEST_IMG_PATH=/Users/<yourname>/src/uruk/resources/ml-favicon.ico`) to your Bash profile (*.bashrc*).
+6. Finally, add environment variable `URUK_TEST_IMG_PATH` (e.g. `export URUK_TEST_IMG_PATH=/path/to/uruk/resources/ml-favicon.ico`) to your Bash profile (*.bashrc*).
 
 You should now be able to run `lein test` and, if you start up a REPL, the examples in *test/uruk/core_test.clj*.
 
@@ -279,7 +282,7 @@ The `insert-string` function used here automatically detects string type and ins
 
 
 ## Uncovered surface area
-Uruk is fully functional and production-ready. However, some aspects of the XCC/J API have not yet been implemented:
+Uruk is sturdy and ready for production. However, some aspects of the XCC/J API have not yet been implemented:
 
   - [JNDI](https://docs.marklogic.com/javadoc/xcc/com/marklogic/xcc/jndi/package-summary.html)
   - [XCC Service Provider Interface](https://docs.marklogic.com/javadoc/xcc/com/marklogic/xcc/spi/package-summary.html) -- note the MarkLogic disclaimer that this is for advanced users only, not endorsed for independent use, and "use at your own risk"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is sponsored by [LambdaWerk](https://lambdawerk.com/home). It is pa
 ## Installation
 [![Clojars Project](https://img.shields.io/clojars/v/uruk.svg)](https://clojars.org/uruk)
 
-In your *project.clj* dependencies: `[uruk "0.3.9"]`
+In your *project.clj* dependencies: `[uruk "0.3.10"]`
 
 In your namespace: `(:require [uruk.core :as uruk])`. (I also like `ur` as an alias, for brevity. Delightfully, Ur is another [ancient city-state with ties to the origins of written documents](https://en.wikipedia.org/wiki/Ur).)
 

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject uruk "0.3.9"
+(defproject uruk "0.3.10"
   :description "Clojure wrapper of MarkLogic XML Content Connector For Java (XCC/J)"
   :url "https://github.com/daveliepmann/uruk"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.marklogic/marklogic-xcc "9.0.1"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [com.marklogic/marklogic-xcc "9.0.3"]
                  ;; required but not included by MarkLogic (e.g. for ContentFactory):
-                 [com.fasterxml.jackson.core/jackson-databind "2.6.3"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.9.3"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.xml "0.1.0-beta2"]
                  [slingshot "0.12.2"]]

--- a/src/uruk/examples/readme.clj
+++ b/src/uruk/examples/readme.clj
@@ -3,59 +3,61 @@
   (:require [uruk.core :as uruk])
   (:import [com.marklogic.xcc ValueFactory]))
 
-;; Basic usage
-(with-open [session (uruk/create-session {:uri xdbc-uri :content-base database-name
-                                          :user database-user :password database-pwd})]
-  (uruk/execute-xquery session xquery-string))
+(comment
 
-;; Concrete example
-(with-open [session (uruk/create-session {:uri "xdbc://localhost:8383/"
-                                          :user "uruk-tester" :password "password"})]
-  (uruk/execute-xquery session "\"hello world\""))
-;; => ("hello world")
+  ;; Basic usage
+  (with-open [session (uruk/create-session {:uri xdbc-uri :content-base database-name
+                                            :user database-user :password database-pwd})]
+    (uruk/execute-xquery session xquery-string))
 
-;; DB info
-(def db {:uri "xdbc://localhost:8383/"
-         :user "uruk-tester" :password "password"
-         :content-base "UrukDB"})
+  ;; Concrete example
+  (with-open [session (uruk/create-session {:uri "xdbc://localhost:8383/"
+                                            :user "uruk-tester" :password "password"})]
+    (uruk/execute-xquery session "\"hello world\""))
+  ;; => ("hello world")
 
-;; Lots of functionality is in the optional config map:
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session
-                       "xquery version \"1.0-ml\"; doc('/bigdoc.xml')"
-                       {:types :raw
-                        :options {:cache-result false}
-                        :variables {:a "a"}
-                        :shape :single}))
+  ;; DB info
+  (def db {:uri "xdbc://localhost:8383/"
+           :user "uruk-tester" :password "password"
+           :content-base "UrukDB"})
+
+  ;; Lots of functionality is in the optional config map:
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session
+                         "xquery version \"1.0-ml\"; doc('/bigdoc.xml')"
+                         {:types :raw
+                          :options {:cache-result false}
+                          :variables {:a "a"}
+                          :shape :single}))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Types
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session "\"hello world\"" {:types :raw}))
-;; => #object[com.marklogic.xcc.impl.CachedResultSequence 0x2c034c22 "CachedResultSequence: size=1, closed=false, cursor=-1"]
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session "\"hello world\"" {:types :raw}))
+  ;; => #object[com.marklogic.xcc.impl.CachedResultSequence 0x2c034c22 "CachedResultSequence: size=1, closed=false, cursor=-1"]
 
-;; Inspecting result types with `result->type`
-(with-open [session (uruk/create-session db)]
-  (uruk/result->type (uruk/execute-xquery session "\"hello world\"" {:types :raw})))
-;; => "xs:string"
+  ;; Inspecting result types with `result->type`
+  (with-open [session (uruk/create-session db)]
+    (uruk/result->type (uruk/execute-xquery session "\"hello world\"" {:types :raw})))
+  ;; => "xs:string"
 
-;; Replacing the default type-conversion functions
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session
-                       "xquery version \"1.0-ml\"; doc('/dir/unwieldy.xml')"
-                       {:types {"document-node()" #(custom-function %)}}))
+  ;; Replacing the default type-conversion functions
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session
+                         "xquery version \"1.0-ml\"; doc('/dir/unwieldy.xml')"
+                         {:types {"document-node()" #(custom-function %)}}))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Shape
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(with-open [session (uruk/create-session {:uri "xdbc://localhost:8383/"
-                                          :user "uruk-tester" :password "password"})]
-  (uruk/execute-xquery session "\"hello world\"" {:shape :single}))
+  (with-open [session (uruk/create-session {:uri "xdbc://localhost:8383/"
+                                            :user "uruk-tester" :password "password"})]
+    (uruk/execute-xquery session "\"hello world\"" {:shape :single}))
 
 
 
@@ -63,101 +65,104 @@
 ;; Inserting elements
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; XXX This section is out of order compared to the README, since we
-;; use the inserted document momentarily in the Options section.
+  ;; XXX This section is out of order compared to the README, since we
+  ;; use the inserted document momentarily in the Options section.
 
-;; Insert a document with a Content Creation Option:
-(with-open [session (uruk/create-session db)]
-  (uruk/insert-element session
-                       "/content-factory/new-doc"
-                       (clojure.data.xml/element :foo)
-                       {:quality 2}))
+  ;; Insert a document with a Content Creation Option:
+  (with-open [session (uruk/create-session db)]
+    (uruk/insert-element session
+                         "/content-factory/new-doc"
+                         (clojure.data.xml/element :foo)
+                         {:quality 2}))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Options
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(with-open [sess (uruk/create-session db)]
-  (uruk/execute-xquery sess "xquery version \"1.0-ml\"; doc('/content-factory/new-doc')"
-                       {:types :raw
-                        :options {:cache-result false}}))
-;; => #object[com.marklogic.xcc.impl.StreamingResultSequence 0x6d7f6 "StreamingResultSequence: closed=true"]
+  (with-open [sess (uruk/create-session db)]
+    (uruk/execute-xquery sess "xquery version \"1.0-ml\"; doc('/content-factory/new-doc')"
+                         {:types :raw
+                          :options {:cache-result false}}))
+  ;; => #object[com.marklogic.xcc.impl.StreamingResultSequence 0x6d7f6 "StreamingResultSequence: closed=true"]
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Variables
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Simple XS_STRING variables:
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session "xquery version \"1.0-ml\";
+  ;; Simple XS_STRING variables:
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session "xquery version \"1.0-ml\";
                                 declare variable $my-variable as xs:string external;
                                 $my-variable"
-                       {:variables {"my-variable" "my-value"}
-                        :shape :single!}))
+                         {:variables {"my-variable" "my-value"}
+                          :shape :single!}))
 
-;; Or use maps describing the variable:
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session "xquery version \"1.0-ml\";
+  ;; Or use maps describing the variable:
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session "xquery version \"1.0-ml\";
                                 declare variable $my-variable as xs:integer external;
                                 $my-variable"
-                       {:variables {"my-variable" {:value 1
-                                                   :type :xs-integer}}
-                        :shape :single!}))
+                         {:variables {"my-variable" {:value 1
+                                                     :type :xs-integer}}
+                          :shape :single!}))
 
-;; Automatic wrapping/conversion of many variable types:
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session "xquery version \"1.0-ml\";
+  ;; Automatic wrapping/conversion of many variable types:
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session "xquery version \"1.0-ml\";
                                 declare variable $my-variable as boolean-node() external;
                                 $my-variable"
-                       {:variables {"my-variable" {:value false
-                                                   :type :boolean-node}}
-                        :shape :single!}))
+                         {:variables {"my-variable" {:value false
+                                                     :type :boolean-node}}
+                          :shape :single!}))
 
-;; As-is:
-(with-open [session (uruk/create-session db)]
-  (uruk/execute-xquery session "xquery version \"1.0-ml\";
+  ;; As-is:
+  (with-open [session (uruk/create-session db)]
+    (uruk/execute-xquery session "xquery version \"1.0-ml\";
                            declare variable $my-variable as boolean-node() external;
                            $my-variable"
-                       {:variables {"my-variable" {:value (-> (com.fasterxml.jackson.databind.node.JsonNodeFactory/instance)
-                                                              (.booleanNode false)
-                                                              ValueFactory/newBooleanNode)
-                                                   :type :boolean-node
-                                                   :as-is? true}}
-                        :shape :single!}))
+                         {:variables {"my-variable" {:value (-> (com.fasterxml.jackson.databind.node.JsonNodeFactory/instance)
+                                                                (.booleanNode false)
+                                                                ValueFactory/newBooleanNode)
+                                                     :type :boolean-node
+                                                     :as-is? true}}
+                          :shape :single!}))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Working within a transaction
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(with-open [session (uruk/create-session db {:transaction-mode :update})]
-  ;; The first request (query) starts a new, multi-statement transaction:
-  (uruk/execute-xquery session "xdmp:document-insert('/docs/mst1.xml', <data><stuff/></data>)")
+  ;; Open a session and configure it to trigger multi-statement transaction use:
+  (with-open [session (uruk/create-session db {:auto-commit? false :update-mode true})]
+    ;; The first request (query) starts a new, multi-statement transaction:
+    (uruk/execute-xquery session "xdmp:document-insert('/docs/mst1.xml', <data><stuff/></data>)")
 
-  ;; This second request executes in the same transaction as the
-  ;; previous request and sees the results of the previous update:
-  (uruk/execute-xquery session "xdmp:document-insert('/docs/mst2.xml', fn:doc(\"/docs/mst1.xml\"));")
+    ;; This second request executes in the same transaction as the
+    ;; previous request and sees the results of the previous update:
+    (uruk/execute-xquery session "xdmp:document-insert('/docs/mst2.xml', fn:doc(\"/docs/mst1.xml\"));")
 
-  ;; After commit, updates are visible to other transactions. Commit
-  ;; ends the transaction after current statement completes.
-  (uruk/commit session) ;; <—- Transaction ends; updates are kept
+    ;; After commit, updates are visible to other transactions. Commit
+    ;; ends the transaction after current statement completes.
+    (uruk/commit session) ;; <—- Transaction ends; updates are kept
 
-  ;; Rollback discards changes and ends the transaction. The following
-  ;; document deletion query never occurs, since it is rolled back
-  ;; before calling commit:
-  (uruk/execute-xquery session "xdmp:document-delete('/docs/mst1.xml')")
-  (uruk/rollback session) ;; <– Transaction ends; updates are lost
+    ;; Rollback discards changes and ends the transaction. The following
+    ;; document deletion query never occurs, since it is rolled back
+    ;; before calling commit:
+    (uruk/execute-xquery session "xdmp:document-delete('/docs/mst1.xml')")
+    (uruk/rollback session) ;; <– Transaction ends; updates are lost
 
-  ;; Closing session without calling commit causes a rollback. The
-  ;; following update is lost, since we don't commit before the end of
-  ;; the (with-open) and its implicit `.close`:
-  (uruk/execute-xquery session "xdmp:document-delete('/docs/mst1.xml')"))
+    ;; Closing session without calling commit causes a rollback. The
+    ;; following update is lost, since we don't commit before the end of
+    ;; the (with-open) and its implicit `.close`:
+    (uruk/execute-xquery session "xdmp:document-delete('/docs/mst1.xml')"))
 
 ;;;; Inserting Clojure XML elements
-(with-open [session (uruk/create-session db)]
-  (uruk/insert-element session "/content-factory/new-doc" (clojure.data.xml/element :foo)))
+  (with-open [session (uruk/create-session db)]
+    (uruk/insert-element session "/content-factory/new-doc" (clojure.data.xml/element :foo)))
 
-(with-open [sess (uruk/create-session db)]
-  (uruk/execute-xquery sess "xquery version \"1.0-ml\"; doc(\"/content-factory/new-doc\")"))
+  (with-open [sess (uruk/create-session db)]
+    (uruk/execute-xquery sess "xquery version \"1.0-ml\"; doc(\"/content-factory/new-doc\")"))
+
+  )

--- a/src/uruk/examples/types.clj
+++ b/src/uruk/examples/types.clj
@@ -4,8 +4,8 @@
 
 (def session
   (create-session {:uri "xdbc://localhost:8383/"
-                   :user "rest-admin" :password "x"
-                   :content-base "TutorialDB"}))
+                   :user "uruk-tester" :password "password"
+                   :content-base "UrukDB"}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Interfaces for JSON

--- a/test/uruk/core_test.clj
+++ b/test/uruk/core_test.clj
@@ -111,13 +111,24 @@
   "True if given session configuration conforms to the expected
   default Session; false otherwise."
   [session]
-  (and (is (instance? RequestOptions (:default-request-options session)))
-       (is (instance? RequestOptions (:effective-request-options session)))
-       (is (and (instance? Logger (:logger session))
-                (= "com.marklogic.xcc" (.getName (:logger session)))))
-       (is (nil? (:user-object session)))
-       (is (= 0 (:transaction-timeout session)))
-       (is (nil? (:transaction-mode session)))))
+  (testing "is default session config?"
+    (testing "default request options are valid?"
+      (is (instance? RequestOptions (:default-request-options session))))
+    (testing "effective request options are valid?"
+      (is (instance? RequestOptions (:effective-request-options session))))
+    (testing "logger is valid?"
+      (is (and (instance? Logger (:logger session))
+               (= "com.marklogic.xcc" (.getName (:logger session))))))
+    (testing "user object not set?"
+      (is (nil? (:user-object session))))
+    (testing "timeout not set, so 0?"
+      (is (= 0 (:transaction-timeout session))))
+    (testing "transaction mode not set, so nil?"
+      (is (nil? (:transaction-mode session)))) ;; XXX DEPRECATED, will be removed in a future version
+    (testing "update-mode not set, so nil?"
+      (is (nil? (:update-mode session))))
+    (testing "auto-commit not set, so nil?"
+      (is (nil? (:auto-commit? session))))))
 
 (deftest default-session-config
   (testing "A session with no explicitly-set configuration must have default configuration"
@@ -168,63 +179,84 @@
   "True if given `session` is configured as according to
   `expected-config`; false otherwise."
   [session expected-config]
-  (and (and (= (:auto-retry-delay-millis (:default-request-options expected-config))
-               (.getAutoRetryDelayMillis (:default-request-options session))
-               (.getAutoRetryDelayMillis (:effective-request-options session)))
-            (= (:cache-result (:default-request-options expected-config))
-               (.getCacheResult (:default-request-options session))
-               (.getCacheResult (:effective-request-options session)))
-            (= (:default-xquery-version (:default-request-options expected-config))
-               (.getDefaultXQueryVersion (:default-request-options session))
-               (.getDefaultXQueryVersion (:effective-request-options session)))
-            (= (:effective-point-in-time (:default-request-options expected-config))
-               (.getEffectivePointInTime (:default-request-options session))
-               (.getEffectivePointInTime (:effective-request-options session)))
-            (= (:locale (:default-request-options expected-config))
-               (.getLocale (:default-request-options session))
-               (.getLocale (:effective-request-options session)))
-            (= (:max-auto-retry (:default-request-options expected-config))
-               (.getMaxAutoRetry (:default-request-options session))
-               (.getMaxAutoRetry (:effective-request-options session)))
+  (testing "session config is as expected?"
+    (testing "auto-retry-delay-millis"
+      (is (= (:auto-retry-delay-millis (:default-request-options expected-config))
+             (.getAutoRetryDelayMillis (:default-request-options session))
+             (.getAutoRetryDelayMillis (:effective-request-options session)))))
+    (testing "cache-result"
+      (is (= (:cache-result (:default-request-options expected-config))
+             (.getCacheResult (:default-request-options session))
+             (.getCacheResult (:effective-request-options session)))))
+    (testing "default-xquery-version"
+      (is (= (:default-xquery-version (:default-request-options expected-config))
+             (.getDefaultXQueryVersion (:default-request-options session))
+             (.getDefaultXQueryVersion (:effective-request-options session)))))
+    (testing "effective-point-in-time"
+      (is (= (:effective-point-in-time (:default-request-options expected-config))
+             (.getEffectivePointInTime (:default-request-options session))
+             (.getEffectivePointInTime (:effective-request-options session)))))
+    (testing "locale"
+      (is (= (:locale (:default-request-options expected-config))
+             (.getLocale (:default-request-options session))
+             (.getLocale (:effective-request-options session)))))
+    (testing "max-auto-retry"
+      (is (= (:max-auto-retry (:default-request-options expected-config))
+             (.getMaxAutoRetry (:default-request-options session))
+             (.getMaxAutoRetry (:effective-request-options session)))))
 
-            (= (:query-language (:default-request-options expected-config))
-               (.getQueryLanguage (:default-request-options session))
-               (.getQueryLanguage (:effective-request-options session)))
-            (= (:request-name (:default-request-options expected-config))
-               (.getRequestName (:default-request-options session))
-               (.getRequestName (:effective-request-options session)))
-            (= (:request-time-limit (:default-request-options expected-config))
-               (.getRequestTimeLimit (:default-request-options session))
-               (.getRequestTimeLimit (:effective-request-options session)))
-            (= (:result-buffer-size (:default-request-options expected-config))
-               (.getResultBufferSize (:default-request-options session))
-               (.getResultBufferSize (:effective-request-options session)))
-            (= (:timeout-millis (:default-request-options expected-config))
-               (.getTimeoutMillis (:default-request-options session))
-               (.getTimeoutMillis (:effective-request-options session)))
-            (= (:timezone (:default-request-options expected-config))
-               (.getTimeZone (:default-request-options session))
-               (.getTimeZone (:effective-request-options session))))
+    (testing "query-language"
+      (is (= (:query-language (:default-request-options expected-config))
+             (.getQueryLanguage (:default-request-options session))
+             (.getQueryLanguage (:effective-request-options session)))))
+    (testing "request-name"
+      (is (= (:request-name (:default-request-options expected-config))
+             (.getRequestName (:default-request-options session))
+             (.getRequestName (:effective-request-options session)))))
+    (testing "request-time-limit"
+      (is (= (:request-time-limit (:default-request-options expected-config))
+             (.getRequestTimeLimit (:default-request-options session))
+             (.getRequestTimeLimit (:effective-request-options session)))))
+    (testing "result-buffer-size"
+      (is (= (:result-buffer-size (:default-request-options expected-config))
+             (.getResultBufferSize (:default-request-options session))
+             (.getResultBufferSize (:effective-request-options session)))))
+    (testing "timeout-millis"
+      (is (= (:timeout-millis (:default-request-options expected-config))
+             (.getTimeoutMillis (:default-request-options session))
+             (.getTimeoutMillis (:effective-request-options session)))))
+    (testing "timezone"
+      (is (= (:timezone (:default-request-options expected-config))
+             (.getTimeZone (:default-request-options session))
+             (.getTimeZone (:effective-request-options session)))))
 
-       (and (instance? Logger (:logger session))
-            (= (.getName (:logger expected-config))
-               (.getName (:logger session))))
-       (= (:user-object expected-config)
-          (:user-object session))
-       (= (:transaction-timeout session)
-          (:transaction-timeout expected-config))
-       (= (:transaction-mode session)
-          (:transaction-mode expected-config))))
+    (testing "logger is instance of Logger?"
+      (is (instance? Logger (:logger session))))
+    (testing "logger name correct?"
+      (is (= (.getName (:logger expected-config))
+             (.getName (:logger session)))))
+    (testing "user-object"
+      (is (= (:user-object expected-config)
+             (:user-object session))))    
+    (testing "transaction-timeout"
+      (is (= (:transaction-timeout session)
+             (:transaction-timeout expected-config))))
+    
+    (testing "update-mode"
+      (is (= (:update-mode session)
+             (:update-mode expected-config))))       
+    (testing "auto-commit?"
+      (is (= (:auto-commit? session)
+             (:auto-commit? expected-config))))))
 
 (deftest set-session-config
-  (testing "A session with explicitly-set configuration must reflect that configuration"
+  (testing "A session with explicitly-set configuration must reflect that configuration..."
     (let [dummy-session (create-session db)
           opts {:default-request-options {:auto-retry-delay-millis 98
                                           :cache-result false
                                           :default-xquery-version "0.9-ml"
                                           ;; XXX requires `xdmp:timestamp` execute privilege on the role for the current user
-                                          :effective-point-in-time (.getCurrentServerPointInTime
-                                                                    dummy-session)
+                                          :effective-point-in-time (.getCurrentServerPointInTime dummy-session)
                                           :locale (Locale. "ru")
                                           :max-auto-retry 17
                                           :query-language "de"
@@ -235,35 +267,36 @@
                                           :timezone (TimeZone/getTimeZone "Pacific/Chuuk")}
                 :logger (Logger/getLogger "test")
                 :transaction-timeout 56
-                :transaction-mode :query}]
+                :auto-commit? false
+                :update-mode :false}]
 
-      (testing "with standard database map"
+      (testing "with standard database map..."
         (with-open [sess (create-session db opts)]
           (as-expected-session-config? (session->map sess) opts)))
-      (testing "with uri content source"
+      (testing "with uri content source..."
         (with-open [sess (create-session
                           db (make-uri-content-source "xdbc://localhost:8383/")
                           opts)]
           (as-expected-session-config? (session->map sess) opts)))
-      (testing "with uri content source using options"
+      (testing "with uri content source using options..."
         (with-open [sess (create-session
                           db (make-uri-content-source "xdbc://localhost:8383/"
                                                       {:preemptive-auth false})
                           opts)]
           (as-expected-session-config? (session->map sess) opts)))
 
-      (testing "with hosted content source"
+      (testing "with hosted content source..."
         (with-open [sess (create-session
                           db (make-hosted-content-source "localhost" 8383)
                           opts)]
           (as-expected-session-config? (session->map sess) opts)))
-      (testing "with hosted content source using content base"
+      (testing "with hosted content source using content base..."
         (with-open [sess (create-session
                           db (make-hosted-content-source "localhost" 8383
                                                          {:content-base "UrukDB"})
                           opts)]
           (as-expected-session-config? (session->map sess) opts)))
-      (testing "with hosted content source using user, password, content-base"
+      (testing "with hosted content source using user, password, content-base..."
         (with-open [sess (create-session
                           db (make-hosted-content-source "localhost" 8383
                                                          {:user "uruk-tester"
@@ -271,7 +304,7 @@
                                                           :content-base "UrukDB"})
                           opts)]
           (as-expected-session-config? (session->map sess) opts)))
-      (testing "with hosted content source using user and password"
+      (testing "with hosted content source using user and password..."
         (with-open [sess (create-session
                           db (make-hosted-content-source "localhost" 8383
                                                          {:user "uruk-tester"
@@ -846,9 +879,9 @@
 (deftest content-source-creation-with-uri
   (testing "content source creation from just a URI"
     (let [cs (make-uri-content-source "xdbc://localhost:8383/")]
-      (and (instance? ContentSource cs)
-           (= 8383 (.getPort (.getConnectionProvider cs)))
-           (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
+      (is (instance? ContentSource cs))
+      (is (= 8383 (.getPort (.getConnectionProvider cs))))
+      (is (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
 
 ;; TODO content source from URI and securityoptions
 ;; (deftest content-source-creation-with-uri-and-security-options
@@ -862,17 +895,17 @@
 (deftest content-source-creation-with-host-and-port
   (testing "content source creation from host and port"
     (let [cs (make-hosted-content-source "localhost" 8383)]
-      (and (instance? ContentSource cs)
-           (= 8383 (.getPort (.getConnectionProvider cs)))
-           (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
+      (is (instance? ContentSource cs))
+      (is (= 8383 (.getPort (.getConnectionProvider cs))))
+      (is (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
 
 (deftest content-source-creation-with-host-port-user-pwd
   (testing "content source creation from host and port"
     (let [cs (make-hosted-content-source "localhost" 8383
                                          {:user "uruk-tester" :password "password"})]
-      (and (instance? ContentSource cs)
-           (= 8383 (.getPort (.getConnectionProvider cs)))
-           (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
+      (is (instance? ContentSource cs))
+      (is (= 8383 (.getPort (.getConnectionProvider cs))))
+      (is (= "localhost" (.getHostName (.getConnectionProvider cs)))))))
 
 ;; TODO with SSLContext
 ;; (comment
@@ -893,14 +926,10 @@
 
 (deftest content-src-options
   (testing "Content Source preemptive-authentication settings"
-    (is (true? (.isAuthenticationPreemptive (make-uri-content-source "xdbc://localhost:8383/"
-                                                                     {:preemptive-auth true}))))
-    (is (false? (.isAuthenticationPreemptive (make-uri-content-source "xdbc://localhost:8383/"
-                                                                      {:preemptive-auth false}))))
-    (is (true? (.isAuthenticationPreemptive (make-hosted-content-source "localhost" 8383
-                                                                        {:preemptive-auth true}))))
-    (is (false? (.isAuthenticationPreemptive (make-hosted-content-source "localhost" 8383
-                                                                         {:preemptive-auth false}))))
+    (is (true? (.isAuthenticationPreemptive (make-uri-content-source "xdbc://localhost:8383/" {:preemptive-auth true}))))
+    (is (false? (.isAuthenticationPreemptive (make-uri-content-source "xdbc://localhost:8383/" {:preemptive-auth false}))))
+    (is (true? (.isAuthenticationPreemptive (make-hosted-content-source "localhost" 8383 {:preemptive-auth true}))))
+    (is (false? (.isAuthenticationPreemptive (make-hosted-content-source "localhost" 8383 {:preemptive-auth false}))))
     ;; TODO with make-cp-content-source, once we want to delve into
     ;; the extreme complexity of ConnectionProvider
     )
@@ -1336,18 +1365,18 @@
 (deftest custom-fns
   (testing "Custom response handling functions"
     (with-open [session (create-session db)]
-      (instance? com.marklogic.xcc.types.impl.XsBooleanImpl
-                 (execute-xquery session "fn:doc-available(\"derp\")"
-                                 {:shape :single!
-                                  :types {"xs:boolean" identity}})))
+      (is (instance? com.marklogic.xcc.types.impl.XsBooleanImpl
+                     (execute-xquery session "fn:doc-available(\"derp\")"
+                                     {:shape :single!
+                                      :types {"xs:boolean" identity}}))))
     (with-open [session (create-session db)]
-      (= "false" (execute-xquery session "fn:doc-available(\"derp\")"
-                                 {:shape :single!
-                                  :types {"xs:boolean" #(.asString %)}})))
+      (is (= "false" (execute-xquery session "fn:doc-available(\"derp\")"
+                                     {:shape :single!
+                                      :types {"xs:boolean" #(.asString %)}}))))
     (with-open [session (create-session db)]
-      (= false (execute-xquery session "fn:doc-available(\"derp\")"
-                               {:shape :single!
-                                :types {"xs:boolean" #(.asBoolean %)}})))))
+      (is (= false (execute-xquery session "fn:doc-available(\"derp\")"
+                                   {:shape :single!
+                                    :types {"xs:boolean" #(.asBoolean %)}}))))))
 
 (deftest string-formats
   (testing "String formats"


### PR DESCRIPTION
Updates dependencies to Clojure 1.9.0 and MarkLogic 9.0-3. 

Support for 9.0-3 includes starting the deprecation process for `transaction-mode` on Sessions and adding instead support for `auto-commit?` and `update-mode`.

What seems to be a bug in Session's new getter methods `isAutoCommit` and `getUpdate`, in which a NullPointerException is raised on calling the getter if the property is not explicitly set on the Session, is handled with a `try`/`catch`.

Tests, examples, and documentation were also improved along the way.